### PR TITLE
Run token verification only on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ cache:
 
 script:
   - npm test
+  - '[ "$TRAVIS_PULL_REQUEST" = "false" ] && npm run test || npm run verify'
 
 git:
   depth: 5

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Contract and coin addresses consumed by Trust Wallet",
   "main": "index.js",
   "scripts": {
+    "verify": "node ./test/verifyTokens",
     "test": "npm run pre-test && node ./test/index.js",
     "pre-test": "find . -name '.DS_Store' -type f -delete"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,4 @@
-const axios = require("axios")
 const fs = require('fs')
-const TRUST_API = `https://api.trustwallet.com/tokens/verification`
-const TOKEN_VERIFICATION_KEY = process.env.TOKEN_VERIFICATION_KEY
 
 const pngExp = /\.png$/
 const upperCaseExp = /[A-F]/
@@ -39,34 +36,14 @@ tokens.forEach(token => {
     }
 })
 
-console.log(`Passed all tests`)
-
 const checkRootDirectory = () => {
     fs.readdirSync(".").forEach(file => {
         if(isFilePng(file)) {
             exitWithMsg(`Move ${file} to ./tokens folder`)
         }
-
+        
     })
 }
 checkRootDirectory()
 
-const verifyTokens = () => {
-    const addresses = tokens.map(token => token.replace('.png', '').toLowerCase())
-    axios.post(TRUST_API, {tokens: addresses}, {
-        headers: {
-            TOKEN_VERIFICATION_KEY
-        }
-    })
-    .then(res => {
-        if (res.status !== 200) {
-            exitWithMsg(`Error verifying tokens`)
-        }
-        console.log(`Tokens were successfully verified`, res.data)
-    })
-    .catch(e => {
-        exitWithMsg(`Failed to verify tokens ${e.message}`)
-    })
-}
-
-verifyTokens()
+console.log(`Passed all tests`)

--- a/test/verifyTokens.js
+++ b/test/verifyTokens.js
@@ -1,0 +1,27 @@
+const axios = require("axios")
+const fs = require('fs')
+
+const TRUST_API = `https://api.trustwallet.com/tokens/verification`
+const TOKEN_VERIFICATION_KEY = process.env.TOKEN_VERIFICATION_KEY
+
+const tokens = fs.readdirSync('./tokens')
+const addresses = tokens.map(token => token.replace('.png', '').toLowerCase())
+axios.post(TRUST_API, {tokens: addresses}, {
+    headers: {
+        TOKEN_VERIFICATION_KEY
+    }
+})
+.then(res => {
+    if (res.status !== 200) {
+        exitWithMsg(`Error verifying tokens`)
+    }
+    console.log(`Tokens were successfully verified`, res.data)
+})
+.catch(e => {
+    exitWithMsg(`Failed to verify tokens ${e.message}`)
+})
+
+const exitWithMsg = (msg) => {
+    console.log(msg)
+    process.exit(1)
+}


### PR DESCRIPTION
Fixes issue when environmental not available on PR originated not from the same repository, instead of verification will happen when PR pass tests and merged to master.
Fixes https://github.com/TrustWallet/tokens/issues/989